### PR TITLE
reduce docker layers using 1 RUN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR $GOPATH/src/app
 
 # Copy the code from the host and compile it.
 COPY . .
-RUN go mod vendor
-RUN CGO_ENABLED=0 GOOS=linux go build -a -v -o pequi .
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+RUN go mod vendor && \
+    go build -a -v -o pequi .
 
 # Use the official Alpine image for a lean production container.
 FROM alpine:3


### PR DESCRIPTION
to keep minus layers in the dockerfile I'm proposing to merge the run command
we won't have an impact on the final build size by using multi-stage build, but we have 1 less layer during generating the build