### PR TITLE
Fix test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,12 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: '1.14'
 
     - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: |
-        go version
-        go get -u github.com/axw/gocov/gocov
+      uses: actions/checkout@v4
 
     - name: Code format
       run: test -z "$(gofmt -d . | tee /dev/stderr)"
@@ -30,11 +25,8 @@ jobs:
     - name: Vet
       run: go vet ./...
 
-    - name: Coverage
-      run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+    - name: Test
+      run: go test -race -covermode=atomic ./...
 
     - name: Build
       run: go build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,10 @@ jobs:
     - name: Install dependencies
       run: |
         go version
-        go get -u golang.org/x/lint/golint
         go get -u github.com/axw/gocov/gocov
 
     - name: Code format
       run: test -z "$(gofmt -d . | tee /dev/stderr)"
-  
-    - name: Lint
-      run: golint ./...
 
     - name: Vet
       run: go vet ./...


### PR DESCRIPTION
Fix `test` workflow by:
- Removing the deprecated tool `golint`.
- Removing unnecessary tool `gocov`.
- Removing Codecov integration step.
- Updating setup-go and checkout actions.
- Updating test command removing the flag that saves the coverage report to a file.

Fixes #23
Fixes #26