### PR TITLE
chore: remove unnecessary step from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,3 @@ jobs:
 
     - name: Test
       run: go test -race -covermode=atomic ./...
-
-    - name: Build
-      run: go build


### PR DESCRIPTION
The test step already builds the app from the source code, perform a build without any special flags seems to be redundant.
